### PR TITLE
Add client user headers to RSS client

### DIFF
--- a/application/config.json.template
+++ b/application/config.json.template
@@ -173,7 +173,12 @@
             }
         ],
         "fallbackChannelPattern": "java-news-and-changes",
-        "pollIntervalInMinutes": 10
+        "pollIntervalInMinutes": 10,
+        "clientRequestHeaders": {
+            "User-Agent": "Mozilla/5.0",
+            "Accept": "application/xhtml+xml,application/xml;",
+            "Accept-Language": "en-US,en;"
+        }
     },
     "memberCountCategoryPattern": "Info"
 }

--- a/application/src/main/java/org/togetherjava/tjbot/config/RSSFeedsConfig.java
+++ b/application/src/main/java/org/togetherjava/tjbot/config/RSSFeedsConfig.java
@@ -3,6 +3,7 @@ package org.togetherjava.tjbot.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -16,7 +17,8 @@ import java.util.Objects;
 public record RSSFeedsConfig(@JsonProperty(value = "feeds", required = true) List<RSSFeed> feeds,
         @JsonProperty(value = "fallbackChannelPattern",
                 required = true) String fallbackChannelPattern,
-        @JsonProperty(value = "pollIntervalInMinutes", required = true) int pollIntervalInMinutes) {
+        @JsonProperty(value = "pollIntervalInMinutes", required = true) int pollIntervalInMinutes,
+        @JsonProperty(value = "clientRequestHeaders") Map<String, String> clientRequestHeaders) {
 
     /**
      * Constructs a new {@link RSSFeedsConfig}.

--- a/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
+++ b/application/src/main/java/org/togetherjava/tjbot/features/rss/RSSHandlerRoutine.java
@@ -103,9 +103,7 @@ public final class RSSHandlerRoutine implements Routine {
         });
 
         this.rssReader = new RssReader();
-        this.rssReader.setUserAgent("Mozilla/5.0");
-        this.rssReader.addHeader("Accept", "application/xhtml+xml,application/xml;");
-        this.rssReader.addHeader("Accept-Language", "en-US,en;");
+        this.config.clientRequestHeaders().forEach(this.rssReader::addHeader);
     }
 
     @Override


### PR DESCRIPTION
Better to have it in the configuration file as default for those who need it than hardcoded in the code.